### PR TITLE
feat: improved robustness of type inference system.

### DIFF
--- a/sqlitex_macros/src/lib.rs
+++ b/sqlitex_macros/src/lib.rs
@@ -430,7 +430,12 @@ fn expand(
                         BaseType::Bool => quote! { bool },
                         BaseType::Text => quote! { &str },
                         BaseType::Blob => quote! { &[u8] },
-                        _ => quote! {},
+                        _ => {
+                            return Err(syn::Error::new(
+                                sql_lit.span(),
+                                "Unable to infer type for `?`. Consider casting with `::` or `CAST AS`",
+                            ));
+                        }
                     };
 
                     let final_type = if bind_type.nullable {
@@ -489,7 +494,12 @@ fn expand(
                         BaseType::Bool => quote! { bool },
                         BaseType::Text => quote! { String },
                         BaseType::Blob => quote! { Vec<u8> },
-                        _ => quote! {},
+                        _ => {
+                            return Err(syn::Error::new(
+                                sql_lit.span(),
+                                "Unable to infer type for `?`. Consider casting with `::` or `CAST AS`",
+                            ));
+                        }
                     };
 
                     let owned_final_type = if bind_type.nullable {
@@ -670,7 +680,12 @@ db.{}_bulk(&bulk)?;
                         BaseType::Text => quote! { String },
                         BaseType::Blob => quote! { Vec<u8> },
                         BaseType::Bool => quote! { bool },
-                        _ => quote! {},
+                        _ => {
+                            return Err(syn::Error::new(
+                                sql_lit.span(),
+                                "Unable to infer return type for this expression. Consider casting with `::` or `CAST AS`",
+                            ));
+                        }
                     };
 
                     let final_ty = if col.data_type.nullable {
@@ -739,7 +754,12 @@ db.{}_bulk(&bulk)?;
                         BaseType::Text => quote! { String },
                         BaseType::Blob => quote! { Vec<u8> },
                         BaseType::Bool => quote! { bool },
-                        _ => quote! {},
+                        _ => {
+                            return Err(syn::Error::new(
+                                sql_lit.span(),
+                                "Unable to infer return type for this expression. Consider casting with `::` or `CAST AS`",
+                            ));
+                        }
                     };
 
                     let final_ty = if col.data_type.nullable {
@@ -771,7 +791,12 @@ db.{}_bulk(&bulk)?;
                         BaseType::Bool => quote! { bool },
                         BaseType::Text => quote! { &str },
                         BaseType::Blob => quote! { &[u8] },
-                        _ => quote! {},
+                        _ => {
+                            return Err(syn::Error::new(
+                                sql_lit.span(),
+                                "Unable to infer type for `?`. Consider casting with `::` or `CAST AS`",
+                            ));
+                        }
                     };
 
                     let final_type = if bind_type.nullable {

--- a/sqlitex_type_inference/Cargo.toml
+++ b/sqlitex_type_inference/Cargo.toml
@@ -7,6 +7,8 @@ description = "type inference for sqlitex"
 
 [dependencies]
 sqlparser = {version = "0.59.0", features = ["visitor"]}
+# qusql-parse = "0.8.0"
+qusql-type = "0.6.0"
 
 [dev-dependencies]
 pretty_assertions = "1.4.1"

--- a/sqlitex_type_inference/src/binding_patterns.rs
+++ b/sqlitex_type_inference/src/binding_patterns.rs
@@ -54,6 +54,22 @@ pub fn get_type_of_binding_parameters(
     sql: &str,
     all_tables: &HashMap<String, Vec<ColumnInfo>>,
 ) -> Result<Vec<Type>, InferenceError> {
+    match get_type_of_binding_parameters_internal(sql, all_tables) {
+        Ok(res) => Ok(res),
+        Err(e) => {
+            if let Ok((_, qusql_args)) = crate::run_qusql_fallback(sql, all_tables) {
+                Ok(qusql_args)
+            } else {
+                Err(e)
+            }
+        }
+    }
+}
+
+fn get_type_of_binding_parameters_internal(
+    sql: &str,
+    all_tables: &HashMap<String, Vec<ColumnInfo>>,
+) -> Result<Vec<Type>, InferenceError> {
     let ast = Parser::parse_sql(&SQLiteDialect {}, sql).map_err(|e| InferenceError {
         start: Location { line: 1, column: 1 },
         end: Location { line: 1, column: 1 },
@@ -107,7 +123,7 @@ pub fn get_type_of_binding_parameters(
             table,
             limit,
             from,
-            or,
+            or: _,
         } => {
             let table_name = match &table.relation {
                 sqlparser::ast::TableFactor::Table { name, .. } => {

--- a/sqlitex_type_inference/src/lib.rs
+++ b/sqlitex_type_inference/src/lib.rs
@@ -369,3 +369,100 @@ pub fn validate_sql_file_syntax(sql: &str) -> Result<(), String> {
         .map_err(|e| format!("Invalid SQL syntax in schema file: {}", e))?;
     Ok(())
 }
+
+pub fn run_qusql_fallback(
+    sql: &str,
+    all_tables: &std::collections::HashMap<String, Vec<crate::table::ColumnInfo>>,
+) -> Result<(Vec<crate::table::ColumnInfo>, Vec<crate::expr::Type>), String> {
+    use qusql_type::{schema::parse_schemas, type_statement, TypeOptions, SQLDialect, SQLArguments, StatementType, Issues};
+    let mut ddl = String::new();
+    for (table_name, cols) in all_tables {
+        ddl.push_str(&format!("CREATE TABLE {} (\n", table_name));
+        let col_defs: Vec<String> = cols.iter().map(|c| {
+            let t = match c.data_type.base_type {
+                crate::expr::BaseType::Integer => "INTEGER",
+                crate::expr::BaseType::Real => "REAL",
+                crate::expr::BaseType::Text => "TEXT",
+                crate::expr::BaseType::Blob => "BLOB",
+                crate::expr::BaseType::Bool => "BOOLEAN",
+                _ => "TEXT",
+            };
+            let nn = if c.data_type.nullable { "" } else { "NOT NULL" };
+            format!("{} {} {}", c.name, t, nn)
+        }).collect();
+        ddl.push_str(&col_defs.join(",\n"));
+        ddl.push_str("\n);\n");
+    }
+
+    let opts = TypeOptions::new()
+        .dialect(SQLDialect::Sqlite)
+        .arguments(SQLArguments::QuestionMark);
+    let mut schema_issues = Issues::new(&ddl);
+    let schemas = parse_schemas(&ddl, &mut schema_issues, &opts);
+
+    let mut query_issues = Issues::new(sql);
+    let stmt_type = type_statement(&schemas, sql, &mut query_issues, &opts);
+
+    if !query_issues.is_ok() {
+        return Err(format!("Qusql failed:\n{}", query_issues));
+    }
+
+    let map_type = |ft: &qusql_type::FullType| -> crate::expr::Type {
+        let type_str = ft.to_string().to_lowercase();
+        let base = if type_str.contains("int") || type_str.contains("i8") || type_str.contains("i16") || type_str.contains("i32") || type_str.contains("i64") || type_str.contains("u8") || type_str.contains("u16") || type_str.contains("u32") || type_str.contains("u64") {
+            crate::expr::BaseType::Integer
+        } else if type_str.contains("float") || type_str.contains("double") || type_str.contains("real") || type_str.contains("f32") || type_str.contains("f64") {
+            crate::expr::BaseType::Real
+        } else if type_str.contains("bool") {
+            crate::expr::BaseType::Bool
+        } else if type_str.contains("blob") || type_str.contains("byte") || type_str.contains("binary") || type_str.contains("geometry") {
+            crate::expr::BaseType::Blob
+        } else if type_str.contains("any") {
+            crate::expr::BaseType::Unknowns
+        } else {
+            crate::expr::BaseType::Text
+        };
+        crate::expr::Type {
+            base_type: base,
+            nullable: !ft.not_null,
+            contains_placeholder: false,
+        }
+    };
+
+    match stmt_type {
+        StatementType::Select { columns, arguments } => {
+            let cols = columns.into_iter().enumerate().map(|(i, c)| {
+                let mut mapped = map_type(&c.type_);
+                let name = c.name.as_ref().map(|id| id.to_string()).unwrap_or_else(|| format!("col_{}", i));
+
+                if mapped.base_type == crate::expr::BaseType::Integer {
+                    for tcols in all_tables.values() {
+                        if let Some(custom) = tcols.iter().find(|tc| tc.name == name)
+                            && custom.data_type.base_type == crate::expr::BaseType::Bool {
+                                mapped.base_type = crate::expr::BaseType::Bool;
+                                break;
+                            }
+                    }
+                }
+                crate::table::ColumnInfo {
+                    name,
+                    data_type: mapped,
+                    has_default: false,
+                }
+            }).collect();
+            let args = arguments.iter().map(|(_, ft)| map_type(ft)).collect();
+            Ok((cols, args))
+        },
+        StatementType::Insert { arguments, .. } |
+        StatementType::Replace { arguments, .. } |
+        StatementType::Update { arguments, .. } |
+        StatementType::Delete { arguments, .. } |
+        StatementType::Call { arguments, .. } => {
+            Ok((vec![], arguments.iter().map(|(_, ft)| map_type(ft)).collect()))
+        },
+        _ => Ok((vec![], vec![]))
+    }
+}
+
+
+

--- a/sqlitex_type_inference/src/select_patterns.rs
+++ b/sqlitex_type_inference/src/select_patterns.rs
@@ -19,6 +19,22 @@ pub fn get_types_from_select(
     sql: &str,
     all_tables: &HashMap<String, Vec<ColumnInfo>>,
 ) -> Result<Vec<ColumnInfo>, String> {
+    match get_types_from_select_internal(sql, all_tables) {
+        Ok(res) => Ok(res),
+        Err(e) => {
+            if let Ok((qusql_cols, _)) = crate::run_qusql_fallback(sql, all_tables) {
+                Ok(qusql_cols)
+            } else {
+                Err(e)
+            }
+        }
+    }
+}
+
+fn get_types_from_select_internal(
+    sql: &str,
+    all_tables: &HashMap<String, Vec<ColumnInfo>>,
+) -> Result<Vec<ColumnInfo>, String> {
     let dialect = SQLiteDialect {};
     let sql = pg_cast_syntax_to_sqlite(sql);
     let ast = Parser::parse_sql(&dialect, &sql).map_err(|e| e.to_string())?;


### PR DESCRIPTION
falls back to qusql type inference in case custom type inference fails. Custom type inference is still needed for more control over certain sql queries like custom error msgs for BOOL, STRICT TABLEs etc.

closes #33